### PR TITLE
[JENKINS-59172] - Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 Jenkins AdoptOpenJDK installer Plugin
 =====================================
 
-Provides an installer for the JDK tool that downloads the JDK from https://adoptopenjdk.net/
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/adoptopenjdk.svg)](https://plugins.jenkins.io/adoptopenjdk)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/adoptopenjdk.svg?color=blue)](https://plugins.jenkins.io/adoptopenjdk)
 
-https://wiki.jenkins.io/display/JENKINS/AdoptOpenJDK+installer+Plugin
+Provides an installer for the JDK tool that downloads the JDK from https://adoptopenjdk.net/
 
 Configure plugin via Groovy script
 ---------

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         </developer>
     </developers>
 
-    <url>https://wiki.jenkins.io/display/JENKINS/AdoptOpenJDK+installer+Plugin</url>
+    <url>https://github.com/jenkinsci/adoptopenjdk-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
FTR https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A

It iproves look-and-feel of https://plugins.jenkins.io/adoptopenjdk by using the GitHub documentation