### PR TITLE
JENKINS-59285 - Handle MacOS releases prior to archive layout change

### DIFF
--- a/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
@@ -195,10 +195,8 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
         if (platform == Platform.MACOS) {
             FilePath contents = children.get(0).child("Contents/Home");
             if (contents.exists() && contents.isDirectory()) return contents;
-        } else {
-            return children.get(0);
         }
-        return null;
+        return children.get(0);
     }
 
     /**


### PR DESCRIPTION
This change adds support for MacOS archives using both the common layout and the special MacOS layout as used by releases after jdk8u172-b11