### PR TITLE
chore: bumped jetty to version 9.4.38.v20210224

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <java.level>8</java.level>
         <jenkins.version>2.164.3</jenkins.version>
         <wiremock.version>2.27.1</wiremock.version>
-        <jetty.version>9.4.35.v20201120</jetty.version>
+        <jetty.version>9.4.38.v20210224</jetty.version>
     </properties>
     <name>AdoptOpenJDK installer Plugin</name>
     <description>Provides an installer for the JDK tool that downloads the JDK from https://adoptopenjdk.net/</description>


### PR DESCRIPTION
Bumped jetty version to fix moderate severity security issue. Jetty is only used for running tests so it's a local issue and not an issue for installed plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
