### PR TITLE
Remove help reference to OpenJ9

### DIFF
--- a/src/main/webapp/version.html
+++ b/src/main/webapp/version.html
@@ -24,11 +24,7 @@
   #L%
   -->
 <div>
-    <p>HotSpot is the VM from the OpenJDK community. It is the most widely used VM today and is used in Oracle’s JDK. It is suitable for all workloads.</p>
+    <p>HotSpot is the Java virtual machine from the OpenJDK community. It is the most widely used VM today. It is suitable for all workloads.</p>
 
-    <p>For more details see <a href="https://openjdk.java.net/groups/hotspot/" target="_blank">OpenJDK HotSpot.</a></p>
-
-    <p>Eclipse OpenJ9 is the VM from the Eclipse community. It is an enterprise-grade VM designed for low memory usage and fast start-up and is used in IBM’s JDK. It is suitable for running all workloads.</p>
-
-    <p>For more details see <a href="https://www.eclipse.org/openj9/" target="_blank">Eclipse OpenJ9.</a></p>
+    <p>For more details see <a href="https://openjdk.org/groups/hotspot/">OpenJDK HotSpot.</a></p>
 </div>


### PR DESCRIPTION
## Remove help reference to OpenJ9

Eclipse Adoptium does not distribute the OpenJ9 VM, so there is no reason to reference it in the help for this plugin.

Follow-up to #23

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
