### PR TITLE
Fix generating empty cache on controller

### DIFF
--- a/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
@@ -97,7 +97,6 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
                 return expected;
             }
             expected.deleteRecursive();
-            expected.mkdirs();
 
             AdoptOpenJDKFamilyList jdkFamilyList = getAdoptOpenJDKFamilyList();
             if (jdkFamilyList.isEmpty()) {


### PR DESCRIPTION
ZipExtractionInstaller.performInstallation() will invoke FilePath.installIfNecessaryFrom() to extract tar ball. When there is no connection to the binary_link and the filepath `expected` exists, no exception will be thrown thus it falls though to generate and send an emptly cache file to the master. Next rounds requests to install the same JDK tool will result in empty tool directory on slave nodes.

Fix that by skip creating empty tool directory on slave nodes.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
