### PR TITLE
Sort Java releases in descending order in selection drop-down

### DIFF
--- a/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
@@ -48,6 +48,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -347,7 +348,9 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
         public AdoptOpenJDKFamilyList toList() throws IOException {
             JSONObject d = getData();
             if (d == null) return new AdoptOpenJDKFamilyList();
-            return (AdoptOpenJDKFamilyList) JSONObject.toBean(d, AdoptOpenJDKFamilyList.class);
+            AdoptOpenJDKFamilyList list = (AdoptOpenJDKFamilyList) JSONObject.toBean(d, AdoptOpenJDKFamilyList.class);
+            Collections.reverse(Arrays.asList(list.data));
+            return list;
         }
     }
 


### PR DESCRIPTION
In order to make the latest Java major versions more accessible sort the major versions in descending order and show the latest version first in the list.
The service release within each section of a major version are already sorted in descending order

### Testing done

Tested the result locally by running `hpi:run -Pjenkins` and inspecting the selection drop-down.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
