### PR TITLE
Fix architecture misclassification for ARM (aarch64, arm) and PowerPC (ppc64le, ppc64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,37 @@ The recommended and preferred approach is to download the JDK distribution using
 well known URL (preferably hosted on your own network) with _ZIP Tool Installer_, having it pre-installed in agent
 docker images, or executing a script to do the job.
 
+## Supported operating systems
+
+JDKs for the following operating systems can be provided
+- ´Linux´
+- ´Windows´
+- ´macOS´
+- ´Solaris´
+- ´AIX´
+- ´Alpine-linux´
+
+Beware that not each possible combination of CPU architectures and operating system is supported.
+
+## Supported CPU architectures
+
+JDKs for the following CPU architectures can be provided
+- `x64`
+- `x32`
+- `aarch64`
+- `arm`
+- `ppc64`
+- `ppc64le`
+- `s390x`
+- `sparcv9`
+- `riscv64`
+
+Beware that not each possible combination of CPU architectures and operating system is supported.
+
+*NOTE*:
+In release `166.v7b_215d91b_68f` and before the architectures `arm` and `aarch64` as well as `ppc64` and `ppc64le` were incorrectly combined.
+This may have led to situations where the wrong one of the two architectures was installed, but is now corrected.
+
 ## Configure plugin with [Configuration as Code](https://plugins.jenkins.io/configuration-as-code/)
 
 The [configuration as code plugin](https://plugins.jenkins.io/configuration-as-code/) allows administrators to automate Jenkins configuration.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ JDKs for the following operating systems can be provided
 - ´AIX´
 - ´Alpine-linux´
 
-Beware that not each possible combination of CPU architectures and operating system is supported.
+Some combinations of CPU architectures and operating systems may not be supported.
 
 ## Supported CPU architectures
 
@@ -39,11 +39,11 @@ JDKs for the following CPU architectures can be provided
 - `sparcv9`
 - `riscv64`
 
-Beware that not each possible combination of CPU architectures and operating system is supported.
+Some combinations of CPU architectures and operating systems may not be supported.
 
 *NOTE*:
 In release `166.v7b_215d91b_68f` and before the architectures `arm` and `aarch64` as well as `ppc64` and `ppc64le` were incorrectly combined.
-This may have led to situations where the wrong one of the two architectures was installed, but is now corrected.
+This may have resulted in situations where a JDK was installed for the wrong architecture. This issue has now been corrected.
 
 ## Configure plugin with [Configuration as Code](https://plugins.jenkins.io/configuration-as-code/)
 

--- a/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
@@ -52,6 +52,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
@@ -289,23 +290,33 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
      * Supported CPU architecture
      */
     public enum CPU {
-        i386,
-        amd64,
-        Sparc,
-        s390x,
-        ppc64,
-        riscv64,
-        arm;
+        // Based on org.apache.commons.lang3.ArchUtils
+        I386("x32", Set.of("x86", "i386", "i486", "i586", "i686", "i86pc")), //
+        AMD64("x64", Set.of("amd64", "x86_64")), //
+        SPARC("sparcv9", Set.of("sparc", "sparcv9")), //
+        S390X("s390x", Set.of("s390x")), //
+        PPC64("ppc64", Set.of("ppc64")), //
+        PPC64LE("ppc64le", Set.of("ppc64le")), //
+        RISCV64("riscv64", Set.of("riscv64")), //
+        ARM("arm", Set.of("arm")), //
+        ARM64("aarch64", Set.of("aarch64", "arm64")), //
+        ;
+
+        private final Set<String> systemNames;
+        final String adoptiumName;
+
+        private CPU(String adoptiumName, Set<String> systemNames) {
+            this.adoptiumName = adoptiumName;
+            this.systemNames = systemNames;
+        }
 
         public static CPU current() throws DetectionFailedException {
             String arch = System.getProperty("os.arch").toLowerCase(Locale.ENGLISH);
-            if (arch.contains("sparc")) return Sparc;
-            if (arch.contains("amd64") || arch.contains("86_64")) return amd64;
-            if (arch.contains("86")) return i386;
-            if (arch.contains("s390x")) return s390x;
-            if (arch.contains("ppc64")) return ppc64;
-            if (arch.contains("riscv64")) return riscv64;
-            if (arch.contains("arm") || arch.contains("aarch64")) return arm;
+            for (CPU cpu : CPU.values()) {
+                if (cpu.systemNames.contains(arch)) {
+                    return cpu;
+                }
+            }
             throw new DetectionFailedException(Messages.AdoptOpenJDKInstaller_CPU_unknownCpu(arch));
         }
     }
@@ -402,36 +413,13 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
             return rhs != null && rhs.equals(release_name);
         }
 
-        public AdoptOpenJDKFile getBinary(Platform platform, CPU cpu) throws IOException {
+        public AdoptOpenJDKFile getBinary(Platform platform, CPU cpu) {
             for (AdoptOpenJDKFile f : binaries) {
                 if (!platform.getId().equals(f.os) || !openjdk_impl.equals(f.openjdk_impl)) {
                     continue;
                 }
-                switch (cpu) {
-                    case i386:
-                        if (f.architecture.equals("x32")) return f;
-                        break;
-                    case amd64:
-                        if (f.architecture.equals("x64")) return f;
-                        break;
-                    case Sparc:
-                        if (f.architecture.equals("sparcv9")) return f;
-                        break;
-                    case ppc64:
-                        if (f.architecture.equals("ppc64") || f.architecture.equals("ppc64le")) return f;
-                        break;
-                    case riscv64:
-                        if (f.architecture.equals("riscv64")) return f;
-                        break;
-                    case s390x:
-                        if (f.architecture.equals("s390x")) return f;
-                        break;
-                    case arm:
-                        if (f.architecture.equals("arm") || f.architecture.equals("aarch64")) return f;
-                        break;
-                    default:
-                        throw new IOException(
-                                Messages.AdoptOpenJDKInstaller_AdoptOpenJDKRelease_usupportedCpu(cpu.name()));
+                if (cpu.adoptiumName.equals(f.architecture)) {
+                    return f;
                 }
             }
             return null;

--- a/src/main/resources/io/jenkins/plugins/adoptopenjdk/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/adoptopenjdk/Messages.properties
@@ -39,5 +39,3 @@ AdoptOpenJDKInstaller.Platform.nullChannel=Channel is null, cannot determine Pla
 AdoptOpenJDKInstaller.Platform.unknownPlatform=Unknown Platform name: {0}
 
 AdoptOpenJDKInstaller.CPU.unknownCpu=Unknown CPU architecture: {0}
-
-AdoptOpenJDKInstaller.AdoptOpenJDKRelease.usupportedCpu=Unsupported CPU architecture: {0}

--- a/src/test/java/io/jenkins/plugins/adoptopenjdk/ConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/adoptopenjdk/ConfigurationTest.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * Eclipse Temurin installer Plugin
+ * %%
+ * Copyright (C) 2026 - 2026 Hannes Wellmann
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+package io.jenkins.plugins.adoptopenjdk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.CPU;
+import io.jenkins.plugins.adoptopenjdk.AdoptOpenJDKInstaller.Platform;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import net.sf.json.JSONArray;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurationTest {
+
+    @Test
+    void allCPUSupported() throws Exception {
+        Collection<String> availableCPUs = fetchList("https://api.adoptium.net/v3/types/architectures");
+
+        Set<String> adoptiumNames =
+                Arrays.stream(CPU.values()).map(c -> c.adoptiumName).collect(Collectors.toSet());
+        assertEquals(new HashSet<>(availableCPUs), adoptiumNames);
+    }
+
+    @Test
+    void allOSSupported() throws Exception {
+        Collection<String> availableOS = fetchList("https://api.adoptium.net/v3/types/operating_systems");
+
+        Set<String> adoptiumNames =
+                Arrays.stream(Platform.values()).map(Platform::getId).collect(Collectors.toSet());
+        assertEquals(new HashSet<>(availableOS), adoptiumNames);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Collection<String> fetchList(String url) throws IOException, MalformedURLException {
+        URI uri = URI.create(url);
+        try (InputStream stream = uri.toURL().openStream()) {
+            String content = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+            JSONArray array = JSONArray.fromObject(content);
+            return JSONArray.toCollection(array, String.class);
+        }
+    }
+}


### PR DESCRIPTION
Streamline determination and handling of CPU architectures.
This also makes the comparison of the reported `os.arch` more precise in order to avoid false positive matches for `I386` and `AMD64` (which was previously only avoided by testing in a specific order).

This also considers the values used in
https://github.com/apache/commons-lang/blob/e10003978ba6bacb7b32c27816b68b858404e967/src/main/java/org/apache/commons/lang3/ArchUtils.java#L103-L137

### Testing done

No extra testing done.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
