### PR TITLE
Add alias for latest service release

### DIFF
--- a/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
@@ -39,7 +39,10 @@ import hudson.tools.ToolInstallation;
 import hudson.tools.ToolInstaller;
 import hudson.tools.ToolInstallerDescriptor;
 import hudson.tools.ZipExtractionInstaller;
+import hudson.util.DirScanner;
+import hudson.util.FileVisitor;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -123,19 +126,16 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
             }
             File cache = getLocalCacheFile(p, c);
             if (!DISABLE_CACHE && cache.exists()) {
-                try (InputStream in = cache.toURI().toURL().openStream()) {
+                try (InputStream in = new FileInputStream(cache)) {
                     CountingInputStream cis = new CountingInputStream(in);
                     try {
                         log.getLogger()
                                 .println(Messages.AdoptOpenJDKInstaller_performInstallation_fromCache(
                                         cache, expected, node.getDisplayName()));
-                        // the zip contains already the directory so we unzip to parent directory
-                        FilePath parent = expected.getParent();
-                        if (parent != null) {
-                            parent.unzipFrom(cis);
-                        } else {
-                            throw new NullPointerException("Parent directory of " + expected + " is null");
-                        }
+                        // the zip contains already the content of the directory
+                        expected.unzipFrom(cis);
+                        // Still handle old cached archives, which have an extra top-level entry
+                        pullUpTopLevelContent(expected, expected, p);
                     } catch (IOException e) {
                         throw new IOException(
                                 Messages.AdoptOpenJDKInstaller_performInstallation_failedToUnpack(
@@ -148,10 +148,7 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
                 ZipExtractionInstaller zipExtractionInstaller = new ZipExtractionInstaller(null, url, null);
                 FilePath installation = zipExtractionInstaller.performInstallation(tool, node, log);
                 installation.child(".timestamp").delete(); // we don't use the timestamp
-                FilePath base = findPullUpDirectory(installation, p);
-                if (base != null && base != expected) {
-                    base.moveAllChildrenTo(expected);
-                }
+                pullUpTopLevelContent(installation, expected, p);
                 marker.write(id, null);
                 if (!DISABLE_CACHE) {
                     // update the local cache on master
@@ -163,7 +160,8 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
                             Files.createDirectories(tmpParent);
                         }
                         try (OutputStream out = Files.newOutputStream(tmp)) {
-                            expected.zip(out);
+                            // Add the JDK directory content directly as top-level entries
+                            expected.zip(out, new DirectContentScanner());
                         }
                         Files.move(tmp, cache.toPath(), StandardCopyOption.REPLACE_EXISTING);
                     } finally {
@@ -181,6 +179,14 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
     private File getLocalCacheFile(Platform platform, CPU cpu) {
         // we force .zip file
         return new File(Jenkins.get().getRootDir(), "caches/adoptopenjdk/" + platform + "/" + cpu + "/" + id + ".zip");
+    }
+
+    private void pullUpTopLevelContent(FilePath actual, FilePath expected, Platform p)
+            throws IOException, InterruptedException {
+        FilePath base = findPullUpDirectory(actual, p);
+        if (base != null && !base.equals(expected)) {
+            base.moveAllChildrenTo(expected);
+        }
     }
 
     /**
@@ -209,7 +215,7 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
     protected FilePath findPullUpDirectory(FilePath root, Platform platform) throws IOException, InterruptedException {
         // if the directory just contains one directory and that alone, assume that's the pull up subject
         // otherwise leave it as is.
-        List<FilePath> children = root.listDirectories();
+        List<FilePath> children = root.list();
         if (children.size() != 1) return null;
 
         // Since the MacOS tar.gz file uses a different layout we need to handle this platform differently
@@ -219,6 +225,24 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
             if (contents.exists() && contents.isDirectory()) return contents;
         }
         return children.get(0);
+    }
+
+    /**
+     * Scans everything recursively within the root file, skipping the root file
+     * itself.
+     */
+    private static class DirectContentScanner extends DirScanner.Full implements Serializable {
+        private static final long serialVersionUID = 6764181784635321066L;
+
+        @Override
+        public void scan(File rootDir, FileVisitor visitor) throws IOException {
+            File[] content = rootDir.listFiles();
+            if (content != null) {
+                for (File file : content) {
+                    super.scan(file, visitor);
+                }
+            }
+        }
     }
 
     private record Configuration(Platform platform, CPU cpu) implements Serializable {

--- a/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
+++ b/src/main/java/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller.java
@@ -4,7 +4,7 @@ package io.jenkins.plugins.adoptopenjdk;
  * #%L
  * Eclipse Temurin installer Plugin
  * %%
- * Copyright (C) 2016 - 2019 Mads Mohr Christensen
+ * Copyright (C) 2016 - 2026 Mads Mohr Christensen
  * %%
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,11 +51,15 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.stream.Stream;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
@@ -71,6 +75,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class AdoptOpenJDKInstaller extends ToolInstaller {
 
     private static boolean DISABLE_CACHE = Boolean.getBoolean(AdoptOpenJDKInstaller.class.getName() + ".cache.disable");
+    private static Long OLD_LATEST_RELEASE_CLEANUP_DAYS =
+            Long.getLong(AdoptOpenJDKInstaller.class.getName() + ".cleanup.days", 30);
 
     /**
      * Eclipse Temurin release id
@@ -87,30 +93,65 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
     private static AdoptOpenJDKFamilyList getAdoptOpenJDKFamilyList() throws IOException {
         AdoptOpenJDKList list = AdoptOpenJDKList.all().get(AdoptOpenJDKList.class);
         if (list == null) {
-            throw new IOException(Messages.AdoptOpenJDKInstaller_getAdoptOpenJDKFamilyList_NoDownloadable());
+            throw new IllegalStateException(Messages.AdoptOpenJDKInstaller_getAdoptOpenJDKFamilyList_NoDownloadable());
         }
         return list.toList();
     }
 
+    private AdoptOpenJDKFamilyList getJDKFamilyList() throws IOException {
+        AdoptOpenJDKFamilyList familyList = getAdoptOpenJDKFamilyList();
+        if (familyList.isEmpty()) {
+            throw new IOException(Messages.AdoptOpenJDKInstaller_performInstallation_emptyJdkFamilyList());
+        }
+        return familyList;
+    }
+
+    // TODO: Check if invocations can be reduced/cached?! per run execution and node
     @Override
     public FilePath performInstallation(ToolInstallation tool, Node node, TaskListener log)
             throws IOException, InterruptedException {
         FilePath expected = preferredLocation(tool, node);
 
         try {
+            final String id; // the (if necessary resolved) id of a specific release
+            AdoptOpenJDKRelease release = null;
+
+            String latestFeature = AdoptOpenJDKFamily.getFeatureVersionIfLatest(this.id);
+            if (latestFeature != null) { // Resolve latest (service) release
+                AdoptOpenJDKFamily featureFamiliy = Arrays.stream(getJDKFamilyList().data)
+                        .filter(f -> latestFeature.equals(f.feature_version))
+                        .findFirst()
+                        .orElseThrow(() -> new IOException(
+                                Messages.AdoptOpenJDKInstaller_performInstallation_releaseNotFound(this.id)));
+                // TODO: Or just get the latest release (less convenient in case the support
+                // matrix changes or some platforms take longer to build).
+                Configuration c = Configuration.of(node);
+                release = Arrays.stream(featureFamiliy.releases)
+                        .filter(r -> r.getBinary(c.platform(), c.cpu()) != null)
+                        .findFirst()
+                        .orElseThrow(
+                                () -> new IOException(Messages.AdoptOpenJDKInstaller_performInstallation_binaryNotFound(
+                                        this.id, c.platform().name(), c.cpu().name())));
+                // Don't change existing installations to prevent problems if another running
+                // job is currently using the old installation.
+                expected = expected.child(release.release_name);
+                cleanupOldReleases(expected);
+                id = release.release_name;
+            } else {
+                id = this.id;
+            }
             // already installed?
             FilePath marker = expected.child(".installedByJenkins");
             if (marker.exists() && marker.readToString().equals(id)) {
+                if (latestFeature != null) {
+                    marker.touch(System.currentTimeMillis());
+                }
                 return expected;
             }
             expected.deleteRecursive();
             expected.mkdirs();
 
-            AdoptOpenJDKFamilyList jdkFamilyList = getAdoptOpenJDKFamilyList();
-            if (jdkFamilyList.isEmpty()) {
-                throw new IOException(Messages.AdoptOpenJDKInstaller_performInstallation_emptyJdkFamilyList());
-            }
-            AdoptOpenJDKRelease release = jdkFamilyList.getRelease(id);
+            release = release == null ? getJDKFamilyList().getRelease(id) : release;
             if (release == null) {
                 throw new IOException(Messages.AdoptOpenJDKInstaller_performInstallation_releaseNotFound(id));
             }
@@ -124,7 +165,7 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
                 throw new IOException(
                         Messages.AdoptOpenJDKInstaller_performInstallation_binaryNotFound(id, p.name(), c.name()));
             }
-            File cache = getLocalCacheFile(p, c);
+            File cache = getLocalCacheFile(p, c, id);
             if (!DISABLE_CACHE && cache.exists()) {
                 try (InputStream in = new FileInputStream(cache)) {
                     CountingInputStream cis = new CountingInputStream(in);
@@ -176,7 +217,24 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
         return expected;
     }
 
-    private File getLocalCacheFile(Platform platform, CPU cpu) {
+    private void cleanupOldReleases(FilePath expected) throws IOException, InterruptedException {
+        if (OLD_LATEST_RELEASE_CLEANUP_DAYS <= 0) {
+            return;
+        }
+        long reference = Instant.now()
+                .minus(Duration.ofDays(OLD_LATEST_RELEASE_CLEANUP_DAYS))
+                .toEpochMilli();
+        for (FilePath directory : expected.getParent().listDirectories()) {
+            if (!directory.equals(expected)) {
+                FilePath marker = directory.child(".installedByJenkins");
+                if (marker.lastModified() < reference) {
+                    directory.deleteRecursive();
+                }
+            }
+        }
+    }
+
+    private File getLocalCacheFile(Platform platform, CPU cpu, String id) {
         // we force .zip file
         return new File(Jenkins.get().getRootDir(), "caches/adoptopenjdk/" + platform + "/" + cpu + "/" + id + ".zip");
     }
@@ -247,12 +305,21 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
 
     private record Configuration(Platform platform, CPU cpu) implements Serializable {
 
-        static Configuration of(Node node) throws IOException, InterruptedException, DetectionFailedException {
+        private static final Map<Node, Configuration> CACHE = new WeakHashMap<>();
+
+        static synchronized Configuration of(Node node)
+                throws IOException, InterruptedException, DetectionFailedException {
+            Configuration configuration = CACHE.get(node);
+            if (configuration != null) {
+                return configuration;
+            }
             VirtualChannel channel = node.getChannel();
             if (channel == null) {
                 throw new IOException(Messages.AdoptOpenJDKInstaller_Platform_nullChannel(node.getDisplayName()));
             }
-            return channel.call(new Configuration.GetCurrent());
+            configuration = channel.call(new Configuration.GetCurrent());
+            CACHE.put(node, configuration);
+            return configuration;
         }
 
         static class GetCurrent extends MasterToSlaveCallable<Configuration, DetectionFailedException> {
@@ -417,12 +484,31 @@ public class AdoptOpenJDKInstaller extends ToolInstaller {
         }
     }
 
+    /**
+     * The group of JDK releases for the same feature (respectively 'major) version.
+     */
     @SuppressFBWarnings(
             value = {"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"},
             justification = "Field initialized during deserialization from JSON object")
     public static final class AdoptOpenJDKFamily {
         public String name;
+        public String feature_version;
         public AdoptOpenJDKRelease[] releases;
+
+        private static final String LATEST_PREFIX = "jdk-";
+        private static final String LATEST_SUFFIX = "-latest";
+
+        public String getLatestRelease() {
+            String feature = feature_version;
+            return feature != null ? LATEST_PREFIX + feature + LATEST_SUFFIX : null;
+        }
+
+        static String getFeatureVersionIfLatest(String id) {
+            if (id.startsWith(LATEST_PREFIX) && id.endsWith(LATEST_SUFFIX)) {
+                return id.substring(LATEST_PREFIX.length(), id.length() - LATEST_SUFFIX.length());
+            }
+            return null;
+        }
     }
 
     @SuppressFBWarnings(

--- a/src/main/resources/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller/config.jelly
@@ -36,6 +36,7 @@
                 <select class="jenkins-select__input" name="_.id">
                     <j:forEach var="family" items="${jdks}">
                         <optgroup label="${family.name}">
+                            <f:option value="${family.latestRelease}" selected="${instance.id == family.latestRelease}">Latest JDK ${family.feature_version} release</f:option>
                             <j:forEach var="jdk" items="${family.releases}">
                                 <f:option value="${jdk.release_name}" selected="${jdk.matchesId(instance.id)}">${jdk.release_name}</f:option>
                             </j:forEach>

--- a/src/main/resources/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller/help.html
+++ b/src/main/resources/io/jenkins/plugins/adoptopenjdk/AdoptOpenJDKInstaller/help.html
@@ -23,7 +23,7 @@
   THE SOFTWARE.
   #L%
   -->
-<div class="warning">
+<div class="info">
     This installation method relies on a third-party service and may
     break at any time without notice. Instead, consider preinstalling a JDK on
     agents, using images that already include a JDK, or downloading the desired


### PR DESCRIPTION
This adds an alias for the latest service release allowing the plugin to update automatically to new service releases of the same feature version.
In the UI it is named `Latest JDK ${feature_version} service release`.
When performing a release of the latest version, the installer resolves the `id` to the latest release of the specified feature-version.

This is currently an early draft as I would like to get feedback about the general direction and have some open questions (as TODOs in the code).
Furthermore, tests are missing.

This also contains/requires
- https://github.com/jenkinsci/adoptopenjdk-plugin/pull/132

### Testing done

Only tested interactively, but unit tests should be added when this PR becomes ready.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
